### PR TITLE
Restore wall "in" start markers

### DIFF
--- a/extensions/th2_template.svg
+++ b/extensions/th2_template.svg
@@ -353,10 +353,10 @@
       <text x="0" y="7" style="fill:#90c;font-size:5;text-anchor:middle">alt</text>
     </marker>
     <marker id="PointInStart" orient="auto">
-      <path d="m0.5,-0.5 0,-3" style="fill:none;stroke:#cc0;stroke-width:1;stroke-opacity:0.7;marker-start:none;marker-end:none" />
+      <path d="m0.5,-0.5 0,-3" style="fill:none;stroke:#cc0;stroke-width:1;stroke-opacity:0.3;marker-start:none;marker-end:none" />
     </marker>
     <marker id="PointInEnd" orient="auto">
-      <path d="m-0.5,-0.5 0,-3" style="fill:none;stroke:#06c;stroke-width:1;stroke-opacity:0.7;marker-start:none;marker-end:none" />
+      <path d="m-0.5,-0.5 0,-3" style="fill:none;stroke:#06c;stroke-width:1;stroke-opacity:0.3;marker-start:none;marker-end:none" />
     </marker>
 	<marker id="ArrowEnd" orient="auto">
 	  <path d="M 5,4 -5,0 5,-4 C 3,-2 3,2 5,4 z"
@@ -733,6 +733,7 @@ path.line.u.purple { stroke:purple }
 
 		path.line.wall {
 			stroke-width:1.2 /* PenA */;
+			marker-start:url(#PointInStart);
 		}
 		path.line.wall.unsurveyed {
 			stroke-width:0.6 /* PenC */;
@@ -743,6 +744,14 @@ path.line.u.purple { stroke:purple }
 		path.line.wall.debris,
 		path.line.wall.pebbles {
 			stroke-width:0.6 /* PenC */;
+		}
+		path.line.wall.blocks,
+		path.line.wall.debris,
+		path.line.wall.pebbles,
+		path.line.wall.sand,
+		path.line.wall.clay {
+			marker-start:none;
+			marker-end:none;
 		}
 		path.line.invisible {
 			stroke-opacity:0.5;

--- a/extensions/th2_template.svg
+++ b/extensions/th2_template.svg
@@ -734,6 +734,7 @@ path.line.u.purple { stroke:purple }
 		path.line.wall {
 			stroke-width:1.2 /* PenA */;
 			marker-start:url(#PointInStart);
+			marker-end:url(#PointInEnd);
 		}
 		path.line.wall.unsurveyed {
 			stroke-width:0.6 /* PenC */;


### PR DESCRIPTION
- Add marker to `line wall`
- No marker for LPE based wall subtypes
- Reduce marker opacity to 0.3

| Inkscape  | XTherion (for comparison) |
| ------------- | ------------- |
| ![inkscape](https://github.com/user-attachments/assets/b548b91f-a497-4078-8a07-659c690f52ca)  | ![xtherion](https://github.com/user-attachments/assets/fef9a0c4-bbd9-44fa-ad80-91218b445784) |

Reverts part of f908efd53fd92f9c782e995f6ce46b615eef8f15

@AHspeleo _Please review_