### PR TITLE
Scrap options in label for th2 export

### DIFF
--- a/extensions/th2_input.py
+++ b/extensions/th2_input.py
@@ -476,10 +476,8 @@ def parse_scrap(a: Sequence[str]):
     e = etree.Element('g')
     e.set(inkscape_groupmode, "layer")
 
-    # e.set(inkscape_label, ' '.join(a))
-    e.set(inkscape_label, a[1])
+    e.set(inkscape_label, ' '.join(a[1:]))
     e.set(therion_role, 'scrap')
-    e.set(therion_options, ' '.join(a[2:]))
 
     options = parse_options(a[2:])
     if "scale" in options:

--- a/extensions/th2_output.py
+++ b/extensions/th2_output.py
@@ -484,9 +484,12 @@ class Th2Output(Th2Effect):
             id = layer.get('id')
         if not id:
             id = 'scrapX'
-        id = id.replace(' ', '_')
+        name, sep, optionstail = id.partition(' -')
+        name = name.rstrip().replace(' ', '_')
+        assert name, f"scrap name missing for layer {id!r}"
         options = parse_options_node(layer)
-        self.print_scrap_begin(id, self.options.lay2scr, options)
+        options.update(parse_options(sep + optionstail))
+        self.print_scrap_begin(name, self.options.lay2scr, options)
         self.output_g(layer)
         self.print_scrap_end(self.options.lay2scr)
 

--- a/tests/data/ink1.svg
+++ b/tests/data/ink1.svg
@@ -6,6 +6,7 @@
    version="1.1"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:therion="http://therion.speleo.sk/therion"
    xmlns="http://www.w3.org/2000/svg">
   <sodipodi:namedview
      pagecolor="#ffffff"
@@ -38,5 +39,11 @@
        style="fill:none;stroke-width:0.5"
        d="m 10,70 c 0,0 10,20 20,20 10 ,0 10,-10 20,-20 10,10 10,20 20,20 10,0 20,-20 20,-20"
        sodipodi:nodetypes="cscsc" />
+  </g>
+  <g
+     id="s_ex_3"
+     therion:options="-projection extended -author 2024 [John Doe]"
+     inkscape:groupmode="layer">
+    <text x="10" y="90" style="font-size:5">Scrap #3 extended elevation</text>
   </g>
 </svg>

--- a/tests/data/ink1.svg
+++ b/tests/data/ink1.svg
@@ -41,6 +41,11 @@
        sodipodi:nodetypes="cscsc" />
   </g>
   <g
+     inkscape:label="s_sec_2   -projection none -scale [20 2 m]"
+     inkscape:groupmode="layer">
+    <text x="10" y="80" style="font-size:5">Scrap #2 cross section</text>
+  </g>
+  <g
      id="s_ex_3"
      therion:options="-projection extended -author 2024 [John Doe]"
      inkscape:groupmode="layer">

--- a/tests/test_th2_output.py
+++ b/tests/test_th2_output.py
@@ -74,5 +74,5 @@ def test_th2_output__options(executable_args):
     th2content = subprocess.check_output(
         executable_args + [m.__file__, "--options", '-author 1984 Mäx', str(path_input)],
         encoding="utf-8")
-    assert 'scrap scrap1 -author 1984 "Mäx" -scale [1000 100 m]\n' in th2content
-    assert 'scrap s_ex_3 -projection extended -author 1984 "Mäx" -scale [1000 100 m]' in th2content
+    assert 'scrap scrap1 -author 1984 "Mäx"\n' in th2content
+    assert 'scrap s_ex_3 -projection extended -author 2024 [John Doe]' in th2content

--- a/tests/test_th2_output.py
+++ b/tests/test_th2_output.py
@@ -51,13 +51,18 @@ def test_th2_output(tmp_path, executable_args):
     path_input = TESTS_DATA / "ink1.svg"
     path_output = tmp_path / "out.th2"
     subprocess.check_call(
-        executable_args + [m.__file__, f"--output={path_output}", str(path_input)])
+        executable_args +
+        [m.__file__, "--projection=plan", "--scale=100", f"--output={path_output}",
+         str(path_input)])
     th2content = path_output.read_text(encoding="utf-8")
     assert re.search(r"point .* altitude", th2content) is not None
     assert re.search(
         r'point .* label .* -text "<lang:de>German<lang:en>English<lang:fr>French"',
         th2content) is not None
     assert TH2_LINE_SMOOTH_OFF in th2content
+
+    assert 'scrap scrap1 -projection plan -scale [1000 100 m]' in th2content
+    assert 'scrap s_ex_3 -projection extended -author 2024 [John Doe] -scale [1000 100 m]' in th2content
 
 
 def test_th2_output__options(executable_args):
@@ -69,4 +74,5 @@ def test_th2_output__options(executable_args):
     th2content = subprocess.check_output(
         executable_args + [m.__file__, "--options", '-author 1984 Mäx', str(path_input)],
         encoding="utf-8")
-    assert 'scrap scrap1 -author 1984 "Mäx"' in th2content
+    assert 'scrap scrap1 -author 1984 "Mäx" -scale [1000 100 m]\n' in th2content
+    assert 'scrap s_ex_3 -projection extended -author 1984 "Mäx" -scale [1000 100 m]' in th2content

--- a/tests/test_th2_output.py
+++ b/tests/test_th2_output.py
@@ -62,6 +62,7 @@ def test_th2_output(tmp_path, executable_args):
     assert TH2_LINE_SMOOTH_OFF in th2content
 
     assert 'scrap scrap1 -projection plan -scale [1000 100 m]' in th2content
+    assert 'scrap s_sec_2 -projection none -scale [20 2 m]' in th2content
     assert 'scrap s_ex_3 -projection extended -author 2024 [John Doe] -scale [1000 100 m]' in th2content
 
 
@@ -75,4 +76,5 @@ def test_th2_output__options(executable_args):
         executable_args + [m.__file__, "--options", '-author 1984 Mäx', str(path_input)],
         encoding="utf-8")
     assert 'scrap scrap1 -author 1984 "Mäx"\n' in th2content
+    assert 'scrap s_sec_2 -projection none -author 1984 "Mäx" -scale [20 2 m]' in th2content
     assert 'scrap s_ex_3 -projection extended -author 2024 [John Doe]' in th2content


### PR DESCRIPTION
Add support for scrap options in the layer label. These options have the highest priority and overwrite global options (command line `--scale`, `--projection`, `--options`). They also overwrite options from the `therion:options` attribute, if present.

![options-prio](https://github.com/user-attachments/assets/7a8dc471-1c18-4f5c-a4d1-7218517afedc)

_Breaking changes:_
- `therion:options` now overwrites command line `--options`
- New default for `--scale` is _undefined_, previous value was 100
- Scrap name ends at first ` -` (space, dash)

@AHspeleo FYI